### PR TITLE
Add asset server image paths used on ubuntu.com

### DIFF
--- a/static/scss/objects/_rowhero.scss
+++ b/static/scss/objects/_rowhero.scss
@@ -26,7 +26,7 @@
       width: 100%;
       height: 100%;
       z-index: 0;
-      background-image: url('../media/hero-images/hero-1.jpg');
+      background-image: url('https://assets.ubuntu.com/v1/8ce3e107-hero-1.jpg');
       background-repeat: no-repeat;
       background-position: 0 12%;
       -ms-background-size: cover;

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
 <section class="row row-hero">
 	<div class="inner-wrapper overflow-hidden">
 		<div class="row-hero__text row-hero__col eight-col margin-top--30 padding-top--30">
-			<h1><img src="/static/img/maas-logo.svg" alt="" class="row-hero__logo" /> Metal as a Service</h1><h1>Say hello to your physical cloud</h1>
+			<h1><img src="https://assets.ubuntu.com/v1/33b96a7f-maas-logo.svg" alt="" class="row-hero__logo" /> Metal as a Service</h1><h1>Say hello to your physical cloud</h1>
 			<h3 class="padding-bottom--30">Total automation of your physical servers for amazing data centre operational efficiency. On premise, open source and supported.</h3>
 			<p>
 				<a href="/get-started" class="row-hero__cta button--primary">Get started</a>
@@ -70,19 +70,19 @@
 		<div class="six-col last-col">
 			<ul class="inline-logos">
 				<li>
-					<img src="../static/media/logos/ubuntu-logo.png" width="150" alt="Ubuntu logo">
+					<img src="https://assets.ubuntu.com/v1/c037fd75-ubuntu-logo.png" width="150" alt="Ubuntu logo">
 				</li>
 				<li>
-					<img src="../static/media/logos/windows-logo.svg" width="120" alt="Windows logo">
+					<img src="https://assets.ubuntu.com/v1/30574235-windows-logo.svg" width="120" alt="Windows logo">
 				</li>
 				<li class="last-item">
-					<img src="../static/media/logos/centos-logo.png" width="150" alt="CentOS logo">
+					<img src="https://assets.ubuntu.com/v1/c69a8b3c-centos-logo.png" width="150" alt="CentOS logo">
 				</li>
 				<li>
-					<img src="../static/media/logos/redhat-logo.svg" width="140" alt="Redhat logo">
+					<img src="https://assets.ubuntu.com/v1/eda6b94a-redhat-logo.svg" width="140" alt="Redhat logo">
 				</li>
 				<li>
-					<img src="../static/media/logos/suse-logo.png"  width="100" alt="Suse logo">
+					<img src="https://assets.ubuntu.com/v1/6697a21a-suse-logo.png"  width="100" alt="Suse logo">
 				</li>
 			</ul>
 		</div>


### PR DESCRIPTION
# Done
Add asset server images that have been used on ubuntu.com, on the homepage takeover and maas page.

## QA
Run make develop and make sure the hero background, the maas logo in the h1 and the logos in the 'The smartest way to manage bare metal’ section all on the homepage, are visible and on the asset server, like.
