### PR TITLE
Replace Google Analytics with Google Tag Manager

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -27,6 +27,18 @@
   </head>
 
   <body class="{% block page_class %}{% endblock %}">
+    <!-- google tag manager -->
+    <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-K92JCQ"height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <script>
+      dataLayer = [];
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-K92JCQ');
+    </script>
+    <!-- end google tag manager -->
+
     <header class="banner global" role="banner">
       <nav role="navigation" class="nav-primary nav-right" id="nav">
         <span id="main-navigation-link"><a href="#main-navigation">Jump to site nav</a></span>

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -129,13 +129,4 @@
   <script src="/static/js/jquery.command-line.js"></script>
   <script src="/static/js/jquery.modal.min.js"></script>
   {% block js-extra %}{% endblock %}
-
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-1018242-58', 'auto');
-    ga('send', 'pageview');
-  </script>
 </html>


### PR DESCRIPTION
Card: https://canonical.leankit.com/Boards/View/111185042/119136403

*NB*: This is based on https://github.com/ubuntudesign/maas.io/pull/28, merge that first.

I've modified the code slightly from the [paste I was given][1], as 
I don't see why there need to be two `<script>` tags. It should still work.
Hopefully we can verify on staging or something.

QA
--

``` bash
make setup develop
```

Check analytics tag isn't visible in markup anywhere on the site, and tag manager is visible everywhere.

I don't know if we can do anything else to verify if tag manager is working at this stage? If so, do it.

[1]: https://pastebin.canonical.com/146480/