### PR TITLE
Add port to get-started step

### DIFF
--- a/templates/get-started.html
+++ b/templates/get-started.html
@@ -91,7 +91,7 @@
                     <input class="command-line__input" value="sudo maas-region-admin createadmin" readonly="readonly">
                     <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
                 </p>
-                <p>Login to the MAAS UI at http://&lt;your.maas.ip&gt;/MAAS/</p>
+                <p>Login to the MAAS UI at http://&lt;your.maas.ip&gt;:5240/MAAS/</p>
             </div>
         </div>
     </section>


### PR DESCRIPTION
# Done
- Add an port to getting to login to the MAAS UI

## QA
- Check the port is added to the URL in step 4

### Detail
- issue https://github.com/ubuntudesign/maas.io/issues/31