### PR TITLE
Make documentation content use flexbox

### DIFF
--- a/config/docs-base.tpl
+++ b/config/docs-base.tpl
@@ -14,7 +14,7 @@
 
       {% include "includes/docs_nav_js.html" %}
 
-      <main id="main-content" class="inner-wrapper">
+      <main id="main-content" class="inner-wrapper documentation__content">
         <div class="row">
           %%CONTENT%%
         </div>

--- a/static/css/docs.scss
+++ b/static/css/docs.scss
@@ -24,6 +24,10 @@
   max-width: 100%;
 }
 
+.documentation__content {
+  display: flex;
+}
+
 // Import normal site header & footer
 // ===
 @import '../../node_modules/cloud-vanilla-theme/scss/build';


### PR DESCRIPTION
This forces the "row" section to expand to fill 100% of the vertical space.

Fixes #38

QA
--

```
make setup
npm install  # Using npm v2
make docs
sass --update static/css/*.scss  # Make sure the sass is built
make develop
```

Now visit `http://127.0.0.1:8000/docs/installconfig-install` and check the white background on the main content extends all the way down.