### PR TITLE
Remove right column

### DIFF
--- a/config/docs-base.tpl
+++ b/config/docs-base.tpl
@@ -19,8 +19,6 @@
           %%CONTENT%%
         </div>
       </main>
-      <aside class="toc">
-      </aside>
     </div>
 
     {% include "includes/footer.html" %}

--- a/config/docs-base.tpl
+++ b/config/docs-base.tpl
@@ -2,7 +2,7 @@
 <html lang="en" dir="ltr">
   {% include "includes/head.html" with css_file="css/docs.css" title="%%TITLE%%" %}
 
-  <body class="documentation-area">
+  <body>
     {% include "includes/tag_manager.html" %}
 
     {% include "includes/header.html" %}
@@ -14,7 +14,7 @@
 
       {% include "includes/docs_nav_js.html" %}
 
-      <main id="main-content" class="inner-wrapper documentation__content">
+      <main id="main-content" class="inner-wrapper documentation__contents">
         <div class="row">
           %%CONTENT%%
         </div>

--- a/static/css/docs.scss
+++ b/static/css/docs.scss
@@ -30,11 +30,6 @@
   }
 }
 
-.toc {
-  position: sticky;
-  padding-left: 40px;
-}
-
 // Import normal site header & footer
 // ===
 @import '../../node_modules/cloud-vanilla-theme/scss/build';

--- a/static/css/docs.scss
+++ b/static/css/docs.scss
@@ -22,6 +22,7 @@
 
 .documentation__contents, .documentation__contents.inner-wrapper {
   margin-left: 0;
+  border-right: 1px solid rgb(205, 205, 205);
   display: flex;
 
   img {

--- a/static/css/docs.scss
+++ b/static/css/docs.scss
@@ -20,12 +20,18 @@
   height: 2.25em;
 }
 
-.documentation-area .inner-wrapper img {
-  max-width: 100%;
+.documentation__contents, .documentation__contents.inner-wrapper {
+  margin-left: 0;
+  display: flex;
+
+  img {
+    max-width: 100%;
+  }
 }
 
-.documentation__content {
-  display: flex;
+.toc {
+  position: sticky;
+  padding-left: 40px;
 }
 
 // Import normal site header & footer


### PR DESCRIPTION
Remove the `.toc` element, and tweak styling so the content still looks left-aligned.

Fixes #37.

QA
---

``` bash
make setup
npm install  # Using npm v2
make docs
sass --update static/css/*.scss  # Make sure the sass is built
make develop
```

Go to `http://127.0.0.1:8000/docs/intro-about-maas` and check the enforced right column is gone, but that the central content still has a max-width.