### PR TITLE
Improve `make docs`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ static/docs/*
 maas-docs/
 docs-env/
 templates/includes/docs_navigation.html
+/tmp/

--- a/Makefile
+++ b/Makefile
@@ -77,53 +77,54 @@ setup: install-dependencies update-env
 dev-server:
 	${VEX} ./manage.py runserver_plus 0.0.0.0:${PORT}
 
-
 ##
 # Pull and build docs from maas-docs repo
 ##
 docs:
+	@echo "- Creating tmp/ directory"
+	mkdir -p tmp
 
-	@echo "- Clean: Remove maas-docs and docs-env"
-	rm -rf maas-docs
-	rm -rf docs-env
-
-	@echo "- Pull down the maas-docs repository"
-	git clone git@github.com:canonicalltd/maas-docs.git
+	@echo "- Updating maas-docs repository"
+	if [ -d tmp/maas-docs ]; then cd tmp/maas-docs && git fetch origin && git reset --hard origin/master && git clean -fd; fi
+	if [ ! -d tmp/maas-docs ]; then git clone git@github.com:canonicalltd/maas-docs.git tmp/maas-docs; fi
 
 	@echo "- Remove all existing built docs and media files"
 	find static/docs/* ! -name 'README.md' -type f -exec rm -rf {} +
 	find templates/docs/* ! -name 'README.md' -type f -exec rm -rf {} +
 
 	@echo "- Substitute our own base.tpl"
-	cp config/docs-base.tpl maas-docs/src/base.tpl
+	cp config/docs-base.tpl tmp/maas-docs/src/base.tpl
 
 	@echo "- Replace '../media' links with '/static/docs'"
-	find maas-docs/src/en -name '*.md' -exec bash -c 'sed -E -e "s~(\.\./|\./)+media/~/static/docs/~" {} > {}.new; mv {}.new {}' \;
+	find tmp/maas-docs/src/en -name '*.md' -exec sed -Ei -e "s~(\.\./|\./)+media/~/static/docs/~" {} \;
 
 	@echo "- Replace relative page links with '/docs/{page}'"
-	find maas-docs/src/en -name '*.md' -exec bash -c 'sed -E -e "s~\]\((.?./|/docs/)*([a-zA-Z][\.a-zA-Z/-]+).html~](/docs/\2~" {} > {}.new; mv {}.new {}' \;
-
-	@echo "- Build the docs templates"
-	sh -c "python3 -m venv docs-env; . docs-env/bin/activate; pip3 install -r maas-docs/requirements.txt; make -C maas-docs build"
-
-	@echo "- Copy templates to templates/docs"
-	cp -r maas-docs/htmldocs/en/* templates/docs/.
-
-	@echo "- Copy media to static/docs"
-	cp -r maas-docs/media/* static/docs/.
+	find tmp/maas-docs/src/en -name '*.md' -exec sed -Ei -e "s~\]\((.?./|/docs/)*([a-zA-Z][\.a-zA-Z/-]+).html~](/docs/\2~" {} \;
 
 	@echo "- Fix links in navigation"
-	sed -E -e "s|href=\" *([a-zA-Z0-9-]+).html|href=\"/docs/\1|" maas-docs/src/navigation.tpl > maas-docs/src/navigation.tpl.new; mv maas-docs/src/navigation.tpl.new maas-docs/src/navigation.tpl
+	sed -Ei -e "s|href=\" *([a-zA-Z0-9-]+).html|href=\"/docs/\1|" tmp/maas-docs/src/navigation.tpl
 
 	@echo "- Remove classes from navigation"
-	sed -Ei -e 's/class="[^"]+"//' maas-docs/src/navigation.tpl
+	sed -Ei -e 's/class="[^"]+"//' tmp/maas-docs/src/navigation.tpl
+	sed -Ei -e 's~intro-about-maas.html~/docs/~' tmp/maas-docs/src/navigation.tpl
+
+	@echo "- Create landing page"
+	if [ ! -e tmp/maas-docs/src/en/index.md ] && [ -e tmp/maas-docs/src/en/intro-about-maas.md ]; then \
+		mv tmp/maas-docs/src/en/intro-about-maas.md tmp/maas-docs/src/en/index.md; \
+		find tmp/maas-docs/src -name '*.md' -o -name '*.tpl' -exec sed -Ei -e "s~/docs/intro-about-maas/?~/docs/~" {} \; ; \
+	fi
+
+	@echo "- Build the docs templates"
+	sh -c "python3 -m venv tmp/docs-env; . tmp/docs-env/bin/activate; pip3 install -r tmp/maas-docs/requirements.txt; make -C tmp/maas-docs build"
+
+	@echo "- Copy templates to templates/docs"
+	cp -r tmp/maas-docs/htmldocs/en/* templates/docs/.
+
+	@echo "- Copy media to static/docs"
+	cp -r tmp/maas-docs/media/* static/docs/.
 
 	@echo "- Copy navigation to /docs/_navigation.html"
-	cp maas-docs/src/navigation.tpl templates/includes/docs_navigation.html
-
-	@echo "- Cleaning up: removing maas-docs and docs-env"
-	rm -rf maas-docs/
-	rm -rf docs-env/
+	cp tmp/maas-docs/src/navigation.tpl templates/includes/docs_navigation.html
 
 ##
 # Build SASS

--- a/templates/includes/docs_nav_js.html
+++ b/templates/includes/docs_nav_js.html
@@ -33,6 +33,13 @@
 
   var items = document.querySelectorAll('.documentation__nav>ul>li');
 
+  var currentPath = location.pathname.replace(/(^\/|\/$)/g, "") + location.hash;
+
+  // Expand first item if we're on landing page
+  if (currentPath == 'docs/' || currentPath == 'docs') {
+    items[0].classList.add('expanded');
+  }
+
   for(var num = 0; num < items.length; num++) {
     var item = items[num];
     var heading = item.querySelector('h4');
@@ -40,7 +47,6 @@
     if (! heading) {continue;}
 
     var section = 'docs/' + heading.innerText.toLowerCase().substring(0,4)
-    var currentPath = location.pathname.replace(/(^\/|\/$)/g, "") + location.hash;
 
     // For lists with child lists, add expand/collapse functionality
     if (item.querySelector('ul')) {

--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -9,7 +9,7 @@
     <ul>
       <li><a href="/get-started" {% if level_1 == 'get-started' %} class="active"{% endif %}>Get started</a></li>
       <li><a href="/tour" {% if level_1 == 'tour' %} class="active"{% endif %}>Tour</a></li>
-      <li><a href="/docs/intro-about-maas" {% if level_1 == 'docs' %} class="active"{% endif %}>Docs</a></li>
+      <li><a href="/docs" {% if level_1 == 'docs' %} class="active"{% endif %}>Docs</a></li>
     </ul>
   </nav>
   <div class="nav-toggle">


### PR DESCRIPTION
Move `intro-about-docs` to `index`, so that we have a proper landing page at /docs

Also make `make docs` more efficient.

Fixes #51

QA
--

``` bash
make setup
npm install  # Using npm v2
make docs
sass --update static/css/*.scss  # Make sure the sass is built
make develop
```

click on "Docs" in the nav, see that it now goes to `/docs`, and that the landing page exists and looks the same.