### PR TITLE
Only strip .html for internal links in navigation

### DIFF
--- a/config/docs-wrapper.jinja2
+++ b/config/docs-wrapper.jinja2
@@ -78,7 +78,9 @@
           {% for item in navigation %}
           <li>
             {% if item.location %}
-            <a href="{{ item.location | replace('.html', '') }}">{{ item.title }}</a>
+            <a href="{{ item.location if '//' in item.location else item.location | replace('.html', '') }}">
+              {{ item.title }}
+            </a>
             {% else %}
             <h4 class="header toggle-target">{{ item.title }}</h4>
             {% endif %}
@@ -88,7 +90,9 @@
               {% for child in item.children %}
               <li class"section">
                 {% if child.location %}
-                <a class"header" href="{{ child.location | replace('.html', '') }}">{{ child.title }}</a>
+                <a class"header" href="{{ child.location if '//' in child.location else child.location | replace('.html', '') }}">
+                  {{ child.title }}
+                </a>
                 {% else %}
                 {{ child.title }}
                 {% endif %}
@@ -96,7 +100,11 @@
                 {% if child.children %}
                 <ul>
                   {% for grandchild in child.children %}
-                  <li><a href="{{ grandchild.location | replace('.html', '') }}">{{ grandchild.title }}</a></li>
+                  <li>
+                    <a href="{{ grandchild.location if '//' in grandchild.location else grandchild.location | replace('.html', '') }}">
+                      {{ grandchild.title }}
+                    </a>
+                  </li>
                   {% endfor %}
                 </ul>
                 {% endif %}


### PR DESCRIPTION
Fixes https://github.com/CanonicalLtd/maas-docs/issues/131

As per the issue, we were stripping .html extensions for external links too, breaking them.

This adds conditionals to only strip the extension if the link doesn't contain `//` - i.e. is internal.

QA
---

``` bash
make docs setup develop
```

Browse to <http://127.0.0.1:8000/docs/en/>, click "API Documentation" in the nav and check it works. Now go back and click around the internal pages in the nav and check they all work too.