### PR TITLE
update contact-us form

### DIFF
--- a/templates/contact-us.html
+++ b/templates/contact-us.html
@@ -393,10 +393,14 @@
 								</label>
 								<textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField  mktoRequired" maxlength="2000"></textarea>
 							</li>
-							<li class="mktField">
-								<input class="mktoField" value="yes" id="NewsletterOpt-In" name="NewsletterOpt-In" type="checkbox">
-								<label class="mktoLabel mktoHasWidth" for="NewsletterOpt-In">I would like to receive occasional news from Canonical by email.</label>
-							</li>
+              <li class="mktField">
+                  <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                  <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I would like to receive occasional news from Canonical by email.</label>
+              </li>
+              <li class="mktField">
+                  <input class="mktoField" value="yes" id="NewsletterOpt-In" name="NewsletterOpt-In" type="checkbox" />
+                  <label class="mktoLabel mktoHasWidth" for="NewsletterOpt-In">I would also like to receive the monthly Cloud Newsletter.</label>
+              </li>
 							<li>All information provided will be handled in accordance with the Canonical <a href="http://www.ubuntu.com/legal" target="_blank">privacy policy</a>.</li>
 							<li class="mktField">
 								<button type="submit" class="mktoButton">Submit</button>


### PR DESCRIPTION
## Done

* update opt-in fields on the contact us form

## QA

1. go to /contact-us and see the new fields


## Issue / Card

From the [brief](https://docs.google.com/document/d/1bdQw7DObSd1tCRDTBMASgkg1zDB-a5LptgKVEKPWdzg/edit#) 'replace the Marketo field linked to the tickbox field (which currently links to the Cloud Newsletter opt-in) with the following *new* field: Canonical Updates Opt-In'

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/20702946/c13a258e-b611-11e6-9928-835b3c76b155.png)

