### PR TITLE
Updates Cisco typo on the home page@

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,7 @@
 			</div>
 			<div class="six-col last-col">
 				<ul class="list list__bullets list--large equal-height">
-					<li>Automate everything from IPMI and PXE to fully converged chassis, including CIsco UCS, HP Moonshot and more</li>
+					<li>Automate everything from IPMI and PXE to fully converged chassis, including Cisco UCS, HP Moonshot and more</li>
 					<li>Integrate with devops automation tools like Juju, Chef, Puppet, SALT, Ansible and more</li>
 					<li>Automatically enable remote access through SSH and Powershell</li>
 					<li>REST API, Web UI and CLI</li>


### PR DESCRIPTION
## Done

- Resolves typo issue raised on the home page of maas.io

## QA

Pull the branch, run ```make develop``` and make sure text ```CIsco``` is read as ```Cisco```

## Issue / Card

Fixes #70 

## Screenshots

_n/a_

