### PR TITLE
Make sure /docs/ redirects as well

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,3 +1,2 @@
-docs(/en/?)?: http://docs.ubuntu.com/maas/2.1/en/
-docs/en/(?P<docs>[^/]*): http://docs.ubuntu.com/maas/2.1/en/{docs}
-
+docs: http://docs.ubuntu.com/maas/2.1/en/
+docs/(?P<docs>.*): http://docs.ubuntu.com/maas/2.1/{docs}


### PR DESCRIPTION
Fixes https://github.com/CanonicalLtd/maas-docs/issues/205.

QA
--

``` bash
make setup develop
```

Go to <http://127.0.0.1:8000/docs/>, you should get redirected to http://docs.ubuntu.com/maas/2.1/en/.